### PR TITLE
Fix comment order

### DIFF
--- a/server/controllers/article/articlesController.js
+++ b/server/controllers/article/articlesController.js
@@ -259,11 +259,11 @@ class ArticlesController {
  * @returns {object} - object representing response message
  */
   static async getAuthorsArticles(req, res, next) {
-    const { authorsId } = req.params;
+    const { id } = req.user;
     try {
       let articles = await Article.findAll(
         {
-          where: { userId: authorsId },
+          where: { userId: id },
           include: [{
             model: User,
             as: 'author',

--- a/server/controllers/comment/commentController.js
+++ b/server/controllers/comment/commentController.js
@@ -59,12 +59,15 @@ export default class CommentController {
             attributes: ['id', 'reaction']
           }
         ],
+        order: [
+          ['createdAt', 'DESC'],
+      ],
         attributes: { exclude: ['userId'] },
         where: { articleId }
         });
 
       if (comments.count == 0) {
-        return res.status(404).json({
+        return res.status(200).json({
           success: false,
           message: 'No Comment for this Article',
         });

--- a/server/controllers/profile/userProfileController.js
+++ b/server/controllers/profile/userProfileController.js
@@ -86,17 +86,10 @@ class UserProfileController {
    * @param {object} next - Error handler
    */
   static async updateUserProfile(req, res, next) {
-    const { userId } = req.params;
     try {
       const { id } = req.user;
-      if(userId !==  id){
-        return res.status(403).json({
-          success: 'false',
-          message: 'You are not permitted to edit this user profile',
-        });
-      }
       const getUser = await User.findOne({
-        where: { id: userId }
+        where: { id }
       });
 
       await User.update(
@@ -111,7 +104,7 @@ class UserProfileController {
           dateOfBirthday: req.body.dob || getUser.dateOfBirthday,
         },
         {
-          where: { id: getUser.userId }
+          where: { id: getUser.id }
         }
       );
 

--- a/server/docs/paths/profile.yaml
+++ b/server/docs/paths/profile.yaml
@@ -1,0 +1,137 @@
+paths:
+  /user/profile/:           
+    post:
+      tags:
+        - Profile
+      summary: User profile
+      produces:
+      - application/json
+      security:
+        - Bearer: []
+      responses:
+        200:
+          description: Response for successful update
+          schema:
+            type: 'object'
+            properties:
+              status:
+                type: 'boolean'
+                example: 'true'
+              message:
+                type: string
+                example: Profile updated successfully
+        401:
+          description: response for unauthorized
+          schema:
+            type: 'object'
+            properties:
+              status:
+                type: 'boolean'
+                example: 'false'
+              message: 
+                type: string
+                example: 'Authentication failed: Please supply a valid token'
+
+  /user/profile/auth:           
+    get:
+      tags:
+        - Profile
+      summary: Get an authenticated user
+      produces:
+      - application/json
+      security:
+        - Bearer: []
+      parameters:
+      - in: path
+        name: userId
+        description: 'The id of the user to be liked by user'
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        200:
+          description: Response for successul profile
+          schema:
+            type: 'object'
+            properties:
+              status:
+                type: 'boolean'
+                example: 'true'
+              message:
+                type: string
+                example: User profile gotten successfully
+        401:
+          description: response for unauthorized
+          schema:
+            type: 'object'
+            properties:
+              status:
+                type: 'boolean'
+                example: 'false'
+              message: 
+                type: string
+                example: 'Authentication failed: Please supply a valid token'
+
+  /user/profile/{id}:           
+    get:
+      tags:
+        - Profile
+      summary: Get an anybody profile
+      produces:
+      - application/json
+      security:
+        - Bearer: []
+      parameters:
+      - in: path
+        name: userId
+        description: The id of the user to be gotten
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        200:
+          description: Response for delete successful
+          schema:
+            type: 'object'
+            properties:
+              status:
+                type: 'boolean'
+                example: 'true'
+              message:
+                type: string
+                example: User 
+        400:
+          description: response for bad request(syntax)
+          schema:
+            type: 'object'
+            properties:
+              status:
+                type: 'boolean'
+                example: 'false'
+              message: 
+                type: string
+                example: 'Invalid Reaction: supply a valid reaction'
+        401:
+          description: response for unauthorized
+          schema:
+            type: 'object'
+            properties:
+              status:
+                type: 'boolean'
+                example: 'false'
+              message: 
+                type: string
+                example: 'Authentication failed: Please supply a valid token'
+        404:
+          description: Response for profile reaction not found
+          schema:
+            type: 'object'
+            properties:
+              status:
+                type: boolean
+                example: false
+              message: 
+                type: string
+                example: User not found

--- a/server/routes/api/v1/articlesRoute.js
+++ b/server/routes/api/v1/articlesRoute.js
@@ -15,6 +15,18 @@ import article from '../../../middlewares/validations/checkIfArticleIsOwnedByUse
 
 const router = Router();
 
+
+
+/**
+* @description - Route to get all articles by an author
+* @returns - It returns a response
+*/
+router.get('/article/author/',
+  JWTAuthentication.authenticateUser,
+  articleController.getAuthorsArticles
+  );
+
+
 /**
  * @description - Route is use to create an article
  * @returns - It returns an article object
@@ -74,13 +86,6 @@ router.delete('/article/:id',
   articleController.deleteArticle
   );
 
-/**
-* @description - Route to get all articles by an author
-* @returns - It returns a response
-*/
-router.get('/article/author/:authorsId',
-  articleController.getAuthorsArticles
-  );
 
 /**
 * @description - Route to search for article using query

--- a/server/routes/api/v1/userProfileRoute.js
+++ b/server/routes/api/v1/userProfileRoute.js
@@ -11,7 +11,7 @@ router.get('/user/profile/auth',
   userProfileController.getLoginUser);
 router.get('/user/profile/:id', uuidValidator.validateUUID,
   userProfileController.getAnyUserProfile);
-router.put('/user/profile/:userId', uuidValidator.validateUUID,
+router.put('/user/profile',
   JWTAuthentication.authenticateUser,
   userProfileController.updateUserProfile);
 export default router;

--- a/tests/articles/articles.test.js
+++ b/tests/articles/articles.test.js
@@ -183,7 +183,7 @@ describe('API endpoint for create articles', () => {
 
   it('Should return 200 for get an author articles', async () => {
     const res = await chai.request(server)
-      .get(`/api/v1/article/author/${userId}`)
+      .get('/api/v1/article/author')
       .set('Authorization', `Bearer ${token}`)
       .send();
     expect(res).to.have.status(200);
@@ -351,7 +351,7 @@ describe('API endpoint for create articles', () => {
 
   it('should fake error for get author article', async () => {
     const req = {
-      params: {
+      user: {
         id: 1
       }
     };
@@ -359,7 +359,7 @@ describe('API endpoint for create articles', () => {
     const res = {};
     const next = sinon.stub();
 
-    sinon.stub(Article, 'findOne').throws();
+    sinon.stub(Article, 'findAll').throws();
 
     await articlesController.getAuthorsArticles(req, res, next);
 

--- a/tests/comments/comment.test.js
+++ b/tests/comments/comment.test.js
@@ -154,7 +154,7 @@ describe('Test for comments crud operations', async () => {
     it('should return 404 if article has no comment', async () => {
       const res = await chai.request(app)
       .get(`/api/v1/article/${articleId2}/comments`);
-      expect(res).to.have.status(404);
+      expect(res).to.have.status(200);
       expect(res.body.success).to.equal(false);
       expect(res.body.message).to.be.equals('No Comment for this Article');
     });

--- a/tests/users/userProfile.test.js
+++ b/tests/users/userProfile.test.js
@@ -41,7 +41,7 @@ describe('API endpoint for user pofile', () => {
       userId: userId,
     });
     await chai.request(url)
-      .put(`/api/v1/user/profile/${userId}`)
+      .put('/api/v1/user/profile/')
       .set('Authorization', `Bearer ${token}`)
       .send(userData)
       .then((res) => {
@@ -49,25 +49,11 @@ describe('API endpoint for user pofile', () => {
       });
   });
 
-  it('should return user not found', async () => {
-    const userData = userProfileFactory.build({
-      userId: fakeId,
-      bio: 'lorem ipsum'
-    });
-    await chai.request(url)
-      .put(`/api/v1/user/profile/${userData.fakeId}`)
-      .set('Authorization', `Bearer ${token}`)
-      .send(userData)
-      .then((res) => {
-        expect(res).to.have.status(403);
-        expect(res.body.message).to.be
-            .equals('You are not permitted to edit this user profile');
-      });
-  });
+
 
   it('should get a login user profile', async () => {
     await chai.request(url)
-      .get('/api/v1/user/profile/auth/')
+      .get('/api/v1/user/profile/auth')
       .set('Authorization', `Bearer ${token}`)
       .send()
       .then((res) => {


### PR DESCRIPTION


#### What does this PR do?
It fixes comment to be ordered by date
#### Description of Task to be completed?
- fix comment order
- fix user profile route to use user token 
#### How should this be manually tested?
``` npm install ```
get ``` http://localhost:3000/api/v1/article/:articleId/comments```
Should return comment in order of date created

put  ``` http://localhost:3000/api/v1/user/profile```
Should be able to update a user profile without specifying user id

#### Any background context you want to provide?
- Fix for the comment to be in order base on the the the comment was made
- fix user profile to use token only
#### What are the relevant pivotal tracker stories?
Nil
#### Screenshots (if appropriate)
Nil