### PR TITLE
user is not able to rate more than once

### DIFF
--- a/server/controllers/rating/ratingController.js
+++ b/server/controllers/rating/ratingController.js
@@ -22,16 +22,33 @@ class RatingController{
       const { articleRating } = req.body;
       const { articleId } = req.params;
       const userId = req.user.id;
-      const ratedArticle = await Rating.create({
-        userId,
-        articleId,
-        articleRating
-      });
-      return res.status(201).json({
-        success: true,
-        message: SUCCESSFUL_RATING,
-        ratedArticle
-      });
+
+      const existingUser = await Rating.findOne(
+        { where: {userId, articleId }}
+      );
+
+      if (existingUser) {
+        const ratedArticle = await Rating.update(
+          { articleRating },
+          { where: {userId, articleId }}
+        );
+        return res.status(200).json({
+          success: true,
+          message: SUCCESSFUL_RATING_UPDATE,
+          ratedArticle
+        });
+      } else {
+          const ratedArticle = await Rating.create({
+            userId,
+            articleId,
+            articleRating
+          });
+          return res.status(201).json({
+            success: true,
+            message: SUCCESSFUL_RATING,
+            ratedArticle
+          });
+    }
     } catch(err) {
       return next(err);
     }

--- a/tests/rating/rating.test.js
+++ b/tests/rating/rating.test.js
@@ -116,6 +116,15 @@ describe('Rating controller', () => {
       expect(response.body.message).to.equal(SUCCESSFUL_RATING);
     });
 
+    it('should update an article rating', async () => {
+      const response = await chai.request(app)
+      .post(`${ratingUrl}`)
+      .send({'articleRating': ratingObject.articleRating})
+      .set('Authorization', readerToken);
+      expect(response).to.have.status(200);
+      expect(response.body).to.be.an('object');
+      expect(response.body.message).to.equal(SUCCESSFUL_RATING_UPDATE);
+    });
 
     it('should not rate an article if the user is the author', async () => {
       const response = await chai.request(app)


### PR DESCRIPTION
#### What does this PR do?
this fix makes sure user is not able to rate more than once.
#### Description of Task to be completed?
N/A
#### How should this be manually tested?
git clone `bg-fix-duplicate-rating`
npm run `test`
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A